### PR TITLE
Cleanup quirks

### DIFF
--- a/alignment.py
+++ b/alignment.py
@@ -39,10 +39,10 @@ def parse_args():
     parser.add_argument("-s", "--stype", default="protein",
                         help="Sequence type (\"protein\" or \"dna\").")
     # TODO: Remove email requirement.
-    parser.add_argument("-e", "--email",
-                        help="Personal email. Used to submit BLAST and Clustal Omega jobs.")
+    #parser.add_argument("-e", "--email",
+                        #help="Personal email. Used to submit BLAST and Clustal Omega jobs.")
     parser.add_argument("-t", "--title", default="alignment",
-                        help="Output title ([TITLE].clustal_num, [TITLE].pim).")
+                        help="Alignment title ([TITLE].clustal, [TITLE].pim).")
 
     return parser.parse_args()
 
@@ -57,10 +57,10 @@ def main(args):
 
     #args = parse_args()
 
-    infile = find_path(args.infile, action="r").replace("\\", "/")
+    infile = find_path(args.infile, "r", "f").replace("\\", "/")
     print(f"Processing sequences from {infile} \n", flush=True)
 
-    out_directory = find_path(args.out_directory, action="w").replace("\\", "/")
+    out_directory = find_path(args.out_directory, "w", "d").replace("\\", "/")
     print(f"Storing outputs in {out_directory}\n", flush=True)
 
     stype = args.stype

--- a/api_funcs.py
+++ b/api_funcs.py
@@ -108,7 +108,7 @@ def verify_sprot():
     """
 
     sprot_path = find_path(f"{os.path.abspath(os.path.dirname(__file__))}/SwissProt/",
-                           action="w")
+                           "w", "d")
     sprot_exists = True
     current_reldate = get_ftp("reldate.txt", sprot_path, action="read")
 
@@ -197,7 +197,7 @@ def blast(infile, stype, out_prefix, num_res="5"):
     """
 
     sprot_path = find_path(f"{os.path.abspath(os.path.dirname(__file__))}/SwissProt/",
-                           action="w")
+                           "w", "d")
     # Variable stype is tied to program.
     if stype == "dna":
         program = "blastx"
@@ -279,7 +279,7 @@ def align(infile, stype, out_directory, title):
     stype_conv = {"protein":"Protein", "dna":"DNA", "rna":"RNA"}
     subprocess.run(["clustalo",
                     "--infile", infile,
-                    "--outfile", f"{out_directory}/{title}.clustal_num",
+                    "--outfile", f"{out_directory}/{title}.clustal",
                     "--seqtype", stype_conv[stype],
                     "--distmat-out", f"{out_directory}/{title}.pim",
                     "--percent-id", "--full",
@@ -297,20 +297,24 @@ def get_metadata(mid):
     """
 
     # TODO: Consider returning only annotations.
-    # Returns entire json.
+    # Returns entire JSON.
     url_metadata = f"https://rest.uniprot.org/uniprotkb/{mid}"
-
+    print(f"Retrieving metadata for {mid}.", flush=True)
     # Set headers to accept JSON.
     headers = {"Accept": "application/json"}
 
-    # Rerun the request until it returns 200.
+    # For this request specfically, terminate if the first request is not 200.
+    # This is to avoid sending requests for non-UniProt accessions.
     current_request = "Metadata retrieval"
     while True:
         try:
             response_metadata = requests.get(url_metadata, headers)
             if response_metadata.status_code != 200:
                 print(f"{current_request} status code: " +
-                      f"{response_metadata.status_code}. Retrying...\n", flush=True)
+                      f"{response_metadata.status_code}.\n" +
+                      f"Failed to retrieve metadata for {mid}. Continuing...\n",
+                      flush=True)
+                return None # Handle Nonetype in script that calls this.
             else:
                 break
 

--- a/clustal_to_svg.py
+++ b/clustal_to_svg.py
@@ -521,10 +521,10 @@ def main(args):
 
     #args = parse_args()
 
-    infile = find_path(args.infile, action="r").replace("\\", "/")
+    infile = find_path(args.infile, "r", "f").replace("\\", "/")
     print(f"Processing sequences from {infile} \n", flush=True)
 
-    out_directory = find_path(args.out_directory, action="w").replace("\\", "/")
+    out_directory = find_path(args.out_directory, "w", "d").replace("\\", "/")
     print(f"Storing outputs in {out_directory}\n", flush=True)
 
     alignment = read_alignment(infile)
@@ -532,14 +532,14 @@ def main(args):
 
     annotations = args.annotations
     if annotations != "":
-        annotations = pd.read_csv(find_path(annotations, "r"), sep="\t")
+        annotations = pd.read_csv(find_path(annotations, "r", "f"), sep="\t")
         features = "TRUE"
     else:
         annotations = pd.DataFrame()
         features = "FALSE"
     alignment.add_features(annotations) # Add nothing if annotations aren't set.
 
-    create_svg(alignment, find_path(out_directory, "w"),
+    create_svg(alignment, find_path(out_directory, "w", "d"),
                codes=args.codes, nums=args.nums, features=features)
 
 if __name__ == "__main__":

--- a/pat_main.py
+++ b/pat_main.py
@@ -48,7 +48,8 @@ def parse_args():
     # Ex. -i ./infile.fasta -o ./out_dir annotate
 
     parser.add_argument("-i", "--infile", type=str, help="Full path of input file")
-    parser.add_argument("-o", "--out_directory", type=str, help="Full path of output directory")
+    parser.add_argument("-o", "--out_directory", type=str,
+                        help="Full path of output directory. Must end with \"/\".")
 
     ## must be after -i and -o (positional)
     #subparsers = parser.add_subparsers(dest='tool_name', help='Tool to execute')
@@ -75,16 +76,28 @@ def parse_args():
 
     #multi = subparsers.add_parser("multi")
     # Will provide a list of 1 or more tools to use with these arguments
-    parser.add_argument("-ord", "--order", nargs="+")
-    parser.add_argument("-s", "--stype", default="protein")
-    parser.add_argument("-e", "--email", default="")
-    parser.add_argument("-nr", "--num_res", default="10")
-    parser.add_argument("-t", "--title", default="alignment")
+    parser.add_argument("-ord", "--order", nargs="+",
+                        help="Order of tools to run (blast, annotate, align, svg)." +
+                        "Ex. --order align svg")
+    parser.add_argument("-s", "--stype", default="protein",
+                        help="Sequence type (\"protein\" or \"dna\").")
+    #parser.add_argument("-e", "--email", default="")
+    parser.add_argument("-nr", "--num_res", default="10",
+                        help="Number of results.")
+    parser.add_argument("-t", "--title", default="alignment",
+                        help="Alignment title ([TITLE].clustal, [TITLE].pim).")
     parser.add_argument("-c", "--codes", default="FALSE")
-    parser.add_argument("-n", "--nums", default="FALSE")
-    parser.add_argument("-u", "--uniprot_format", default="FALSE")
+    parser.add_argument("-n", "--nums", default="FALSE",
+                        help="When set to TRUE, includes total residue numbers " +
+                        "at the end of each line."                        )
+    parser.add_argument("-u", "--uniprot_format", default="TRUE",
+                        help="When set to TRUE, truncates all accessions as if " +
+                        "they were UniProt entries.\n" +
+                        "Ex. sp|P00784|PAPA1_CARPA -> PAPA1_CARPA"                        )
     # Will annotate if this is provided at all; cannot be nonetype.
-    parser.add_argument("-a", "--annotations", default="")
+    parser.add_argument("-a", "--annotations", default="",
+                        help="If an annotation file is provided, it will be " +
+                        "used to annotate the resulting SVG files."                        )
 
     return parser.parse_args()
 
@@ -258,7 +271,7 @@ def find_outputs(args):
         # This is a TSV of all annotations for a particular FASTA.
         new_inputs.append(f"{args.out_directory}/all.ann".replace("//", "/"))
     elif tool_name == "blast":
-        proteins = fasta_to_df(find_path(args.infile, "r"))
+        proteins = fasta_to_df(find_path(args.infile, "r", "f"))
         for prot in proteins.index.values:
             # Fastas of blast hits.
             new_inputs.append(f"{args.out_directory}/{prot}/all.fasta".replace("//", "/"))

--- a/protein_classes.py
+++ b/protein_classes.py
@@ -70,7 +70,7 @@ class Protein:
         feature.set_clust_positions(clust_start, clust_end)
         self.features.append(feature)
 
-    def set_disp_name(self, length=1000, uniprot_format="FALSE"):
+    def set_disp_name(self, length=1000, uniprot_format="FALSE", query="FALSE"):
         """
         Sets a shorter display name for this protein.
 
@@ -82,10 +82,12 @@ class Protein:
                                   Ex. sp|P00784|PAPA1_CARPA -> PAPA1_CARPA
         """
 
-        if uniprot_format == "TRUE":
-            self.disp_name = self.name.split("|")[-1][:length]
+        if query == "TRUE":
+            self.disp_name = self.disp_name.replace("QUERY_", "")[:length]
+        elif uniprot_format == "TRUE":
+            self.disp_name = self.disp_name.split("|")[-1][:length]
         else:
-            self.disp_name = self.name[:length]
+            self.disp_name = self.disp_name[:length]
 
 class Alignment:
     """

--- a/retrieve_annotations.py
+++ b/retrieve_annotations.py
@@ -41,32 +41,32 @@ def parse_args():
 
     return parser.parse_args()
 
-# TODO: Figure out another way to handle queries.
-def remove_query(uniprot_df):
-    """
-    Takes in command-line arguments and returns an argparse Namespace object.
+## TODO: Figure out another way to handle queries.
+#def remove_query(uniprot_df):
+    #"""
+    #Takes in command-line arguments and returns an argparse Namespace object.
 
-        Parameters:
-            uniprot_df (pandas,DataFrame): Dataframe of input UniProt sequences.
-                                   May include a query sequence from search_proteins.py.
+        #Parameters:
+            #uniprot_df (pandas,DataFrame): Dataframe of input UniProt sequences.
+                                   #May include a query sequence from search_proteins.py.
 
-        Returns:
-            uniprot_df (pandas,DataFrame): Dataframe with no query sequence from search_proteins.py.
-    """
+        #Returns:
+            #uniprot_df (pandas,DataFrame): Dataframe with no query sequence from search_proteins.py.
+    #"""
 
-    for protein in uniprot_df.index.values:
-        acc = uniprot_df.loc[protein, "Accession"]
-        if isinstance(acc, pd.Series):
-            for i, duplicate_acc in enumerate(acc):
-                print(duplicate_acc)
-                duplicate_acc = acc[i]
-                print(duplicate_acc)
-                if "QUERY_" in duplicate_acc:
-                    uniprot_df = uniprot_df[uniprot_df["Accession"] != duplicate_acc]
-        else:
-            if "QUERY_" in acc:
-                uniprot_df = uniprot_df.drop(uniprot_df[uniprot_df["Accession"] == acc].index)
-    return uniprot_df
+    #for protein in uniprot_df.index.values:
+        #acc = uniprot_df.loc[protein, "Accession"]
+        #if isinstance(acc, pd.Series):
+            #for i, duplicate_acc in enumerate(acc):
+                #print(duplicate_acc)
+                #duplicate_acc = acc[i]
+                #print(duplicate_acc)
+                #if "QUERY_" in duplicate_acc:
+                    #uniprot_df = uniprot_df[uniprot_df["Accession"] != duplicate_acc]
+        #else:
+            #if "QUERY_" in acc:
+                #uniprot_df = uniprot_df.drop(uniprot_df[uniprot_df["Accession"] == acc].index)
+    #return uniprot_df
 
 def main(args):
     """
@@ -80,12 +80,12 @@ def main(args):
 
     #args = parse_args()
 
-    infile = find_path(args.infile, action="r").replace("\\", "/")
+    infile = find_path(args.infile, "r", "f").replace("\\", "/")
     print(f"Processing sequences from {infile}\n", flush=True)
     proteins = []
     if infile.endswith(".fasta"):
         infile_df = fasta_to_df(infile)
-        infile_df = remove_query(infile_df)
+        #infile_df = remove_query(infile_df)
         for prot in infile_df.index.values:
             if isinstance(infile_df.loc[prot, "Accession"], pd.Series):
                 # Only use the first accession that IS NOT the query
@@ -102,17 +102,17 @@ def main(args):
         print("Infile does not have a \".fasta\", \".clustal\", " +
               "or \".clustal_num\" extension.\nAssuming FASTA file.\n", flush=True)
         infile_df = fasta_to_df(infile)
-        infile_df = remove_query(infile_df)
+        #infile_df = remove_query(infile_df)
         for prot in infile_df.index.values:
             if isinstance(infile_df.loc[prot, "Accession"], pd.Series):
-                # only use the first accession that IS NOT the query
+                # Only use the first accession that IS NOT the query.
                 acc = infile_df.loc[prot, "Accession"][0][1:]
                 print(f"Duplicate accessions for ID: {prot}.\nProceeding with {acc}.\n", flush=True)
             else:
                 acc = infile_df.loc[prot, "Accession"][1:]
             proteins.append((prot, acc.split(" ")[0]))
 
-    out_directory = find_path(args.out_directory, action="w").replace("\\", "/")
+    out_directory = find_path(args.out_directory, "w", "d").replace("\\", "/")
     print(f"Storing outputs in {out_directory}\n", flush=True)
 
     features_df_list = []
@@ -121,7 +121,11 @@ def main(args):
         whole_prot = prot_names[1]
         metadata = af.get_metadata(prot)
 
-        features = metadata.get("features")
+        if metadata is not None:
+            features = metadata.get("features")
+        else:
+            features = None
+
         if features is not None:
             features_df = pd.json_normalize(features)
         else:

--- a/search_proteins.py
+++ b/search_proteins.py
@@ -41,8 +41,8 @@ def parse_args():
     parser.add_argument("-s", "--stype", default="protein",
                         help="Sequence type (\"protein\" or \"dna\").")
     # TODO: Remove email requirement.
-    parser.add_argument("-e", "--email", help="Personal email. " +
-                        "Used to submit BLAST and Clustal Omega jobs.")
+    #parser.add_argument("-e", "--email", help="Personal email. " +
+                        #"Used to submit BLAST and Clustal Omega jobs.")
     parser.add_argument("-nr", "--num_res", default="10", help="Number of results.")
 
     return parser.parse_args()
@@ -60,11 +60,11 @@ def main(args):
 
     # TODO: Add in translation feature later maybe...or just remove dna.
 
-    infile = find_path(args.infile, action="r").replace("\\", "/")
+    infile = find_path(args.infile, "r", "f").replace("\\", "/")
     print(f"Processing sequences from {infile}\n", flush=True)
     infile_df = fasta_to_df(infile)
 
-    out_directory = find_path(args.out_directory, action="w").replace("\\", "/")
+    out_directory = find_path(args.out_directory, "w", "d").replace("\\", "/")
     print(f"Storing outputs in {out_directory}\n", flush=True)
 
     # Check for Swiss-Prot files in installation path.
@@ -77,7 +77,7 @@ def main(args):
         sequence = infile_df.loc[protein]["Sequence"]
         accession = infile_df.loc[protein]["Accession"] # Includes ">".
 
-        prot_directory = find_path(f"{out_directory}/{protein}/", action="w")
+        prot_directory = find_path(f"{out_directory}/{protein}/", "w", "d")
         out_prefix = f"{prot_directory}/{protein}"
 
         # Saves a FASTA query file.
@@ -99,7 +99,7 @@ def main(args):
         # No header in command-line blastp outfmt6.
         for line in blast_results.split("\n")[0:-1]:
             hit = line.split("\t")[1]
-            print(f"Found BLAST hit: {hit}\n", flush=True)
+            print(f"Found BLAST hit: {hit}", flush=True)
 
             hit_name = hit.split(" ")[0].split("|")[-1]
             hit_fasta = af.get_fasta(hit_name)


### PR DESCRIPTION
helpers.find_path() now requires a path_type argument. It has different functionality for reading/writing files/directories. Output directories no longer have to have "/" at the end.

main.py renamed to pat_main.py

"QUERY_" (from BLAST results) should not show up in SVG protein names.

Non-UniProt entries are ignored by api_funcs.get_metadata() after one failed request.